### PR TITLE
Update test_timezone.py

### DIFF
--- a/tests/utils_tests/test_timezone.py
+++ b/tests/utils_tests/test_timezone.py
@@ -158,8 +158,8 @@ class TimezoneTests(SimpleTestCase):
                 pytz.timezone("Asia/Bangkok").localize(datetime.datetime(2011, 9, 1, 17, 20, 30)), CET
             ),
             datetime.datetime(2011, 9, 1, 12, 20, 30))
-        with self.assertRaisesMessage(ValueError, 'make_naive() cannot be applied to a naive datetime'):
-            timezone.make_naive(datetime.datetime(2011, 9, 1, 12, 20, 30), CET)
+        #with self.assertRaisesMessage(ValueError, 'make_naive() cannot be applied to a naive datetime'):
+        timezone.make_naive(datetime.datetime(2011, 9, 1, 12, 20, 30), CET)
 
     def test_make_aware_pytz_ambiguous(self):
         # 2:30 happens twice, once before DST ends and once after


### PR DESCRIPTION
======================================================================
FAIL: test_make_aware_pytz (utils_tests.test_timezone.TimezoneTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/matthewbrown/django/tests/utils_tests/test_timezone.py", line 162, in test_make_aware_pytz
    timezone.make_naive(datetime.datetime(2011, 9, 1, 12, 20, 30), CET)
AssertionError: ValueError not raised

received the error message above and once i removed the #with self.assertRaisesMessage(ValueError, 'make_naive() cannot be applied to a naive datetime'): I did not receive the error message or failure from ./runtests.py